### PR TITLE
Fix the computation of phi

### DIFF
--- a/src/bblock/CMakeLists.txt
+++ b/src/bblock/CMakeLists.txt
@@ -7,6 +7,7 @@ set(BBLOCK_SOURCES system.cpp sys_tools.cpp external_call.cpp)
 add_library(bblock OBJECT ${BBLOCK_SOURCES})
 target_include_directories(bblock PRIVATE ${CMAKE_SOURCE_DIR}) 
 target_include_directories(bblock PRIVATE ${CMAKE_SOURCE_DIR}/../external/kdtree/)
+target_link_libraries(bblock PUBLIC fftw::fftw)
 
 install(TARGETS bblock
         OBJECTS DESTINATION ${CMAKE_INSTALL_OBJDIR})

--- a/src/io_tools/CMakeLists.txt
+++ b/src/io_tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(io_tools OBJECT read_nrg.cpp write_nrg.cpp) 
+target_link_libraries(io_tools PUBLIC fftw::fftw)
 target_include_directories(io_tools PRIVATE ${CMAKE_SOURCE_DIR}) 
 target_include_directories(io_tools PRIVATE ${CMAKE_SOURCE_DIR}/../external/kdtree/) 

--- a/src/potential/electrostatics/electrostatics.cpp
+++ b/src/potential/electrostatics/electrostatics.cpp
@@ -1376,6 +1376,7 @@ void Electrostatics::CalculateGradients(std::vector<double> &grad) {
                                                   m, m + 1, nmon, nmon, i, j, aDD, aCD_, Asqsqi, &ex, &ey, &ez, &phi1,
                                                   phi_.data() + fi_sites, grad_.data() + fi_crd, elec_scale_factor,
                                                   ewald_alpha_, use_pbc_, box_, box_inverse_, cutoff_);
+                    phi_[fi_sites + inmon + m] += phi1;
                     grad_[fi_crd + inmon3 + m] += ex;
                     grad_[fi_crd + inmon3 + nmon + m] += ey;
                     grad_[fi_crd + inmon3 + nmon2 + m] += ez;
@@ -1527,9 +1528,7 @@ void Electrostatics::CalculateGradients(std::vector<double> &grad) {
         auto coords = helpme::Matrix<double>(sys_xyz_.data(), nsites_, 3);
         auto dipoles = helpme::Matrix<double>(sys_mu_.data(), nsites_, 3);
         auto charges = helpme::Matrix<double>(sys_chg_.data(), nsites_, 1);
-        std::vector<double> tmp(10 * nsites_);
-        auto result = helpme::Matrix<double>(tmp.data(), nsites_, 10);
-        std::fill(tmp.begin(), tmp.end(), 0);
+        auto result = helpme::Matrix<double>(nsites_, 10);
         pme_solver_.computePRec(-1, dipoles, coords, coords, 2, result);
 
         // Resort field from system order
@@ -1546,6 +1545,7 @@ void Electrostatics::CalculateGradients(std::vector<double> &grad) {
                     const double *result_ptr = result[fi_sites + mns + i];
                     const double chg = sys_chg_[fi_sites + mns + i];
                     const double *mu = &sys_mu_[fi_crd + 3 * mns + 3 * i];
+                    double Phi = result_ptr[0];
                     double Erec_x = result_ptr[1];
                     double Erec_y = result_ptr[2];
                     double Erec_z = result_ptr[3];
@@ -1558,6 +1558,7 @@ void Electrostatics::CalculateGradients(std::vector<double> &grad) {
                     double Grad_x = chg * Erec_x;
                     double Grad_y = chg * Erec_y;
                     double Grad_z = chg * Erec_z;
+                    phi_[fi_sites + i * nmon + m] += Phi;
 #if !DIRECT_ONLY
                     Grad_x += Erec_xx * mu[0] + Erec_xy * mu[1] + Erec_xz * mu[2];
                     Grad_y += Erec_xy * mu[0] + Erec_yy * mu[1] + Erec_yz * mu[2];
@@ -1573,9 +1574,8 @@ void Electrostatics::CalculateGradients(std::vector<double> &grad) {
             fi_crd += nmon * ns * 3;
         }
         // Now grid up the charges
-        std::fill(tmp.begin(), tmp.end(), 0);
-        auto fieldgrad = helpme::Matrix<double>(tmp.data(), nsites_, 10);
-        pme_solver_.computePRec(0, charges, coords, coords, -2, fieldgrad);
+        result.setZero();
+        pme_solver_.computePRec(0, charges, coords, coords, -2, result);
 
         // Resort field from system order
         fi_mon = 0;
@@ -1588,7 +1588,7 @@ void Electrostatics::CalculateGradients(std::vector<double> &grad) {
             for (size_t m = 0; m < nmon; m++) {
                 size_t mns = m * ns;
                 for (size_t i = 0; i < ns; i++) {
-                    const double *result_ptr = fieldgrad[fi_sites + mns + i];
+                    const double *result_ptr = result[fi_sites + mns + i];
                     const double *mu = &sys_mu_[fi_crd + 3 * mns + 3 * i];
                     double Erec_xx = result_ptr[0];
                     double Erec_xy = result_ptr[1];


### PR DESCRIPTION
The finite difference test still fails, but much later on after a number of successful comparison.  An atom probably crosses the 9A cutoff in the finite difference procedure, or something like that.   The same thing happens in the dispersion test.  Either way, the code appears to be correct now.  I also made a small build change for our cluster.