### PR TITLE
increment indx for each monomer type

### DIFF
--- a/src/bblock/system.cpp
+++ b/src/bblock/system.cpp
@@ -2063,7 +2063,7 @@ double System::Get1B(bool do_grads) {
         // Update current_coord and curr_mon_type
         current_coord += 3 * mon_type_count_[k].second * sites_[curr_mon_type];
         curr_mon_type += mon_type_count_[k].second;
-        indx = iend;
+        indx += iend;
     }
 
     return e1b;


### PR DESCRIPTION
With this fix, energies, forces, and virials are consistent for NaCl+H2O input-decks. Systems with only two monomer types were not affected by this issue.